### PR TITLE
Add a function to split MySQL schema files into statements

### DIFF
--- a/sql/mysql_split.go
+++ b/sql/mysql_split.go
@@ -1,0 +1,58 @@
+package sql
+
+import (
+	"regexp"
+	"strings"
+)
+
+var delimiterCommandRe = regexp.MustCompile(`(?im)\A\s*delimiter\s*(\S+)\s*$`)
+
+// MysqlSplitStatements takes a string containing multiple SQL statements and splits them into individual statements
+// with limited support for the DELIMITER keyword like implemented by the mysql command line client.
+//
+// The main purpose of this function is to allow importing a schema file containing stored functions from Go. Such files
+// have to specify an alternative delimiter internally if the function has semicolons in its body, otherwise the mysql
+// command line clients splits the CREATE FUNCTION statement somewhere in the middle. This delimiter handling is not
+// supported by the MySQL server, so when trying to import such a schema file using a different method than the mysql
+// command line client, the delimiter handling has to be reimplemented. This is what this function does.
+//
+// To avoid an overly complex implementation, this function has some limitations on its input:
+// - Specifying a delimiter using a quoted string is NOT supported.
+// - Statements are only split if the delimiter appears at the end of a line. This in done in order to avoid
+//   accidentally splitting in the middle of string literals and comments.
+// - The function does not attempt to handle comments in any way, so there must not be a delimiter at the end of a line
+//   within a comment.
+// - The delimiter command is only recognized at the beginning of the file or immediately following a delimiter at the
+//   end of a previous line, there must not be a comment in between, empty lines are fine.
+func MysqlSplitStatements(statements string) []string {
+	delimiterRe := makeDelimiterRe(";")
+
+	var result []string
+
+	for len(statements) > 0 {
+		if match := delimiterCommandRe.FindStringSubmatch(statements); match != nil {
+			delimiterRe = makeDelimiterRe(match[1])
+			statements = statements[len(match[0]):]
+			continue
+		}
+
+		split := delimiterRe.Split(statements, 2)
+
+		if statement := strings.TrimSpace(split[0]); len(statement) > 0 {
+			result = append(result, statement)
+		}
+
+		if len(split) > 1 {
+			statements = split[1]
+		} else {
+			statements = ""
+		}
+
+	}
+
+	return result
+}
+
+func makeDelimiterRe(delimiter string) *regexp.Regexp {
+	return regexp.MustCompile(`(?m)` + regexp.QuoteMeta(delimiter) + `$`)
+}

--- a/sql/mysql_split_test.go
+++ b/sql/mysql_split_test.go
@@ -1,0 +1,56 @@
+package sql
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMysqlSplitQueries(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{{
+		name:  "empty",
+		input: "",
+		want:  nil,
+	}, {
+		name:  "default_delimiter",
+		input: "q1;\nq2;\nq3;\n",
+		want:  []string{"q1", "q2", "q3"},
+	}, {
+		name:  "delimiter_at_eof",
+		input: "q1;",
+		want:  []string{"q1"},
+	}, {
+		name:  "delimiter_switch",
+		input: "q1;\ndelimiter //\nq2//\ndelimiter ;\nq3;\n",
+		want:  []string{"q1", "q2", "q3"},
+	}, {
+		name:  "delimiter_as_column_name",
+		input: "SELECT 1 AS\ndelimiter WHERE\n1=1;\nSELECT 42 WHERE\n1=1",
+		want:  []string{"SELECT 1 AS\ndelimiter WHERE\n1=1", "SELECT 42 WHERE\n1=1"},
+	}, {
+		name:  "delimiter_as_value",
+		input: "SELECT ';';\ndelimiter //\nSELECT '//'//",
+		want:  []string{"SELECT ';'", "SELECT '//'"},
+	}, {
+		name:  "delimiters_but_no_queries",
+		input: "DELIMITER //\nDELIMITER ;",
+		want:  nil,
+	}, {
+		name:  "extra_newlines",
+		input: "\n\n\nSELECT 1;\n\n\nDELIMITER //\n\n\nSELECT 42//\n\n\nSELECT 23\n\n\n",
+		want:  []string{"SELECT 1", "SELECT 42", "SELECT 23"},
+	}, {
+		name:  "ignore_empty_statements",
+		input: "SELECT 1\n;\n;\nSELECT 2\n;\n;\nSELECT 3\n;\n;\n",
+		want:  []string{"SELECT 1", "SELECT 2", "SELECT 3"},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, MysqlSplitStatements(tt.input), "MysqlSplitStatements(%v)", tt.input)
+		})
+	}
+}


### PR DESCRIPTION
Importing stored functions that contain `;` in their body using the `mysql` command line client, you have to use something like `DELIMITER //` so that the function is not split somewhere in the middle. However, this delimiter keyword is only implemented in the client and not supported by the server. So in order to import such a file from Go, you have to split the file respecting the `delimiter` keyword yourself.

This PR adds a function that allows splitting a schema file in that way. To keep the implementation simple, a number of restrictions are imposed on the allowed delimiters and on the file in general, please see the documentation comment for details.

This is a prerequisite for https://github.com/Icinga/icingadb/pull/247 and should also later also be used in the entrypoint of the Icinga DB docker image.